### PR TITLE
get chrome_bin dynamically

### DIFF
--- a/R/aaa.r
+++ b/R/aaa.r
@@ -1,1 +1,3 @@
-chrome_bin <- Sys.getenv("HEADLESS_CHROME")
+chrome_bin <- function() {
+  Sys.getenv("HEADLESS_CHROME")
+}

--- a/R/headless.r
+++ b/R/headless.r
@@ -12,7 +12,7 @@ decapitate <- function(port=9222L, url=NULL) {
   if (!is.null(url)) args <- c(args, "--dump-dom", url)
 
 
-  tmp <- system2(chrome_bin, args, wait=FALSE, stdout=tf, stderr=tf)
+  tmp <- system2(chrome_bin(), args, wait=FALSE, stdout=tf, stderr=tf)
 
   message(sprintf("Log file is at [%s]", tf))
 

--- a/R/read-html.r
+++ b/R/read-html.r
@@ -7,7 +7,7 @@
 #' @examples
 #' chrome_read_html("https://www.r-project.org/")
 chrome_read_html <- function(url) {
-  tmp <- system2(chrome_bin, c("--version", "--headless", "--disable-gpu", "--dump-dom", url), stdout=TRUE)
+  tmp <- system2(chrome_bin(), c("--version", "--headless", "--disable-gpu", "--dump-dom", url), stdout=TRUE)
   xml2::read_html(tmp)
 }
 
@@ -20,7 +20,7 @@ chrome_read_html <- function(url) {
 #' @examples
 #' chrome_dump_pdf("https://www.r-project.org/")
 chrome_dump_pdf <- function(url) {
-  tmp <- system2(chrome_bin, c("--version", "--headless", "--disable-gpu", "--print-to-pdf", url))
+  tmp <- system2(chrome_bin(), c("--version", "--headless", "--disable-gpu", "--print-to-pdf", url))
 }
 
 #' Capture a screenshot
@@ -48,7 +48,7 @@ chrome_shot <- function(url, width=NULL, height=NULL) {
 
   args <- c(args, url)
 
-  tmp <- system2(chrome_bin, args)
+  tmp <- system2(chrome_bin(), args)
 
   magick::image_read("screenshot.png")
 

--- a/R/version.r
+++ b/R/version.r
@@ -1,4 +1,4 @@
 #' Get Chrome version
 #'
 #' @export
-chrome_version <- function(x) { system2(chrome_bin, "--version") }
+chrome_version <- function(x) { system2(chrome_bin(), "--version") }


### PR DESCRIPTION
I'm not really sure, but this line seems a mistake which assigns `chrome_bin` the value of `HEADLESS_CHROME` envvar **at the installation**. Is this intended...? Or am I wrong?

https://github.com/ropenscilabs/decapitated/blob/eac67bd28f81b988078f1a7de5a28b250887f4e6/R/aaa.r#L1

(While I can't succeed to use decapitated on my Windows so far, I send this PR in case this is useful)